### PR TITLE
Fix broken URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ```
 
 ## Update:
-**An New Version of This Payload Is Available [HERE](https://github.com/CosmodiumCS/payloads)**
+**An New Version of This Payload Is Available [HERE](https://github.com/CosmodiumCS/payloads/tree/main/rubberducky/DucKey-Logger)**
 
 ## Overview:
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ```
 
 ## Update:
-**An New Version of This Payload Is Available [HERE](https://github.com/CosmodiumCS/DucKeyhook)**
+**An New Version of This Payload Is Available [HERE](https://github.com/CosmodiumCS/payloads)**
 
 ## Overview:
 ```


### PR DESCRIPTION
You can point to https://github.com/CosmodiumCS/payloads.. Or to https://github.com/CosmodiumCS/payloads/tree/main/rubberducky/DucKey-Logger 